### PR TITLE
Add GitHub Actions workflow for backend build

### DIFF
--- a/.github/workflows/backend_build.yaml
+++ b/.github/workflows/backend_build.yaml
@@ -1,0 +1,62 @@
+name: Build and push Validator backend application image
+
+on:
+  push:
+    paths:
+      - validator/backend/**
+    branches: [dev, test, main]
+  workflow_dispatch:
+
+# Cancel any currently running builds to save GitHub Actions hours.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Validator backend build and push
+    runs-on: ubuntu-latest
+    # Don't run on forks
+    if: github.repository == 'bcgov/standard-graphemes'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Determine environment tag
+        id: env-tag
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            echo "tag=dev" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/test" ]]; then
+            echo "tag=test" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "tag=prod" >> $GITHUB_ENV
+          else
+            echo "Unknown branch. Exiting..."
+            exit 1
+        shell: bash
+
+      - name: Build image with docker build
+        run: docker build ./validator/backend/ -f ./validator/backend/Dockerfile -t validator-backend:latest --build-arg GITHUB_SHA=${{ github.sha }}
+
+      - name: Login to OpenShift Silver image registry
+        uses: docker/login-action@v3
+        with:
+          registry: image-registry.apps.silver.devops.gov.bc.ca
+          # This refers to the serviceaccount name alone, not the fully qualified
+          # value that comes out of `oc whoami` when logged in as the SA.
+          # Ex: For `system:serviceaccount:<name space>:<service account name>`,
+          # just use `<service account name>`.
+          username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
+
+      - name: Tag and push Docker image
+        run: |
+          docker tag validator-backend:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/validator-backend:${{ env.tag }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/validator-backend --all-tags


### PR DESCRIPTION
This adds a GitHub Actions workflow file for building the validator backend application and pushing the resulting image to OpenShift. I've added the secrets referenced in the workflow file as secrets on this GitHub repository.