### PR TITLE
Add explicit end to bash loop in validator backend GHA workflow

### DIFF
--- a/.github/workflows/backend_build.yaml
+++ b/.github/workflows/backend_build.yaml
@@ -40,6 +40,7 @@ jobs:
           else
             echo "Unknown branch. Exiting..."
             exit 1
+          fi
         shell: bash
 
       - name: Build image with docker build


### PR DESCRIPTION
This explicitly closes the Bash `if` loop in the GitHub Actions workflow file that builds the validator backend. This attempts to fix the [broken build here](https://github.com/bcgov/standard-graphemes/actions/runs/12058116871).