### PR TITLE
Set VITE_API_BASE_URL in CI pipeline

### DIFF
--- a/.github/workflows/frontend_build.yaml
+++ b/.github/workflows/frontend_build.yaml
@@ -35,10 +35,13 @@ jobs:
           echo "Evaluating branch: ${{ github.ref }}";
           if [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
             echo "tag=dev" >> $GITHUB_ENV;
+            echo "VITE_API_BASE_URL=https://validator-backend-${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE}}-dev.apps.silver.devops.gov.bc.ca" >> $GITHUB_ENV;
           elif [[ "${{ github.ref }}" == "refs/heads/test" ]]; then
             echo "tag=test" >> $GITHUB_ENV;
+            echo "VITE_API_BASE_URL=https://validator-backend-${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE}}-test.apps.silver.devops.gov.bc.ca" >> $GITHUB_ENV;
           elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "tag=prod" >> $GITHUB_ENV;
+            echo "VITE_API_BASE_URL=https://validator-backend-${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE}}-prod.apps.silver.devops.gov.bc.ca" >> $GITHUB_ENV;
           else
             echo "Unknown branch: ${{ github.ref }}. Exiting...";
             exit 1;
@@ -46,7 +49,7 @@ jobs:
         shell: bash
 
       - name: Build image with docker build
-        run: docker build ./validator/frontend/ -f ./validator/frontend/Dockerfile -t validator-frontend:latest --build-arg GITHUB_SHA=${{ github.sha }}
+        run: docker build ./validator/frontend/ -f ./validator/frontend/Dockerfile -t validator-frontend:latest --build-arg VITE_API_BASE_URL=${{ env.VITE_API_BASE_URL }}
 
       - name: Login to OpenShift Silver image registry
         uses: docker/login-action@v3

--- a/validator/frontend/Dockerfile
+++ b/validator/frontend/Dockerfile
@@ -5,6 +5,11 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install
 COPY . .
+
+# Pass the API base URL during build time
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
 RUN npm run build
 
 # Serve stage

--- a/validator/openshift/backend/dev-deployment.yaml
+++ b/validator/openshift/backend/dev-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: f343b4-dev
+  name: validator-backend
+  annotations:
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"validator-backend:dev","namespace":"f343b4-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","pause":"false"}]
+spec:
+  selector:
+    matchLabels:
+      app: validator-backend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: validator-backend
+    spec:
+      containers:
+        - name: container
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/f343b4-tools/validator-backend@sha256:975be6e790df9a96b77526d5089ceda0fc57c55263344400fe15e9c7c9ad94fd
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env: []
+      imagePullSecrets: []
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
+  paused: false

--- a/validator/openshift/backend/dev-route.yaml
+++ b/validator/openshift/backend/dev-route.yaml
@@ -1,0 +1,19 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: validator-backend
+  namespace: f343b4-dev
+  labels: {}
+spec:
+  to:
+    kind: Service
+    name: validator-backend
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: ""
+  path: /
+  port:
+    targetPort: 3000
+  alternateBackends: []

--- a/validator/openshift/backend/dev-service.yaml
+++ b/validator/openshift/backend/dev-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: validator-backend
+  namespace: f343b4-dev
+spec:
+  selector:
+    app: validator-backend
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 3000

--- a/validator/openshift/frontend/dev-deployment.yaml
+++ b/validator/openshift/frontend/dev-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: f343b4-dev
+  name: validator-frontend
+  annotations:
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"validator-frontend:dev","namespace":"f343b4-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","pause":"false"}]
+spec:
+  selector:
+    matchLabels:
+      app: validator-frontend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: validator-frontend
+    spec:
+      containers:
+        - name: container
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/f343b4-tools/validator-frontend@sha256:d82d580c51d630c879df87b6d4f69dbcaf42e34ccf48e207db19f3aeebe9843b
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env: []
+      imagePullSecrets: []
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
+  paused: false

--- a/validator/openshift/frontend/dev-route.yaml
+++ b/validator/openshift/frontend/dev-route.yaml
@@ -1,0 +1,19 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: validator-frontend
+  namespace: f343b4-dev
+  labels: {}
+spec:
+  to:
+    kind: Service
+    name: validator-frontend
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: ""
+  path: /
+  port:
+    targetPort: 5173
+  alternateBackends: []

--- a/validator/openshift/frontend/dev-service.yaml
+++ b/validator/openshift/frontend/dev-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: validator-frontend
+  namespace: f343b4-dev
+spec:
+  selector:
+    app: validator-frontend
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 5173

--- a/validator/openshift/network-policy-allow-from-openshift-ingress.yaml
+++ b/validator/openshift/network-policy-allow-from-openshift-ingress.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
This sets the `VITE_API_BASE_URL` in the frontend GitHub Actions workflow to build the app, and uses it in the frontend Dockerfile. This variable is set dynamically based on the `dev`/`test`/`prod` branch being merged into.