### PR TITLE
Add resource requests to Validator backend and frontend dev deployments

### DIFF
--- a/validator/openshift/backend/dev/deployment.yaml
+++ b/validator/openshift/backend/dev/deployment.yaml
@@ -25,6 +25,10 @@ spec:
             - containerPort: 8080
               protocol: TCP
           env: []
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "20m"
       imagePullSecrets: []
   strategy:
     type: RollingUpdate

--- a/validator/openshift/frontend/dev/deployment.yaml
+++ b/validator/openshift/frontend/dev/deployment.yaml
@@ -25,6 +25,10 @@ spec:
             - containerPort: 8080
               protocol: TCP
           env: []
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "20m"
       imagePullSecrets: []
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
This adds minimal resource requests to the Deployment objects for the grapheme validator app (backend and frontend) in the `-dev` namespace, to give extra resources for other items hosted in this namespace (CrunchyDB instance).