### PR TITLE
Change frontend Nginx log location from /tmp/ to /var/log/nginx/

### DIFF
--- a/validator/frontend/nginx.conf
+++ b/validator/frontend/nginx.conf
@@ -22,8 +22,8 @@ http {
     gzip_types *;
 
     index index.html;
-    error_log  /tmp/error.log;
-    access_log /tmp/access.log;
+    error_log  /var/log/nginx/error.log warn;
+    access_log /var/log/nginx/access.log combined;
 
     location / {
       root /usr/share/nginx/html;


### PR DESCRIPTION
This change is meant to try getting the frontend Vite app's Nginx access logs to show up in OpenShift where they currently do not.