### PR TITLE
OCR API endpoint uses fully qualified URL in production

### DIFF
--- a/validator/frontend/src/layout/Confusables/OpticalCharacterRecognition/OcrUpload.tsx
+++ b/validator/frontend/src/layout/Confusables/OpticalCharacterRecognition/OcrUpload.tsx
@@ -25,8 +25,15 @@ export default function OcrUpload() {
       setLoading(true);
       setError(null);
 
+      // In local development, proxying is handled by the configuration defined
+      // in vite.config.ts. In production, we need a full base URL.
+      const API_BASE_URL =
+        import.meta.env.MODE === "development"
+          ? ""
+          : import.meta.env.VITE_API_BASE_URL;
+
       // Send the image to the /ocr endpoint
-      const response = await fetch("/api/v1/confusable/ocr", {
+      const response = await fetch(`${API_BASE_URL}/api/v1/confusable/ocr`, {
         method: "POST",
         body: formData,
       });


### PR DESCRIPTION
This change is to allow the OCR API endpoint to work in environments besides local development. Right now, calls to the OCR endpoint don't make it past the Nginx server that serves the Vite frontend (Nginx returns 405 Not Allowed). With this change, requests to `/api/v1/confusable/ocr` will go straight to the Hono.js API backend in production.