### PR TITLE
Add GHA workflow to build graphemes-api on merge

### DIFF
--- a/.github/workflows/graphemes_api_build.yaml
+++ b/.github/workflows/graphemes_api_build.yaml
@@ -65,4 +65,4 @@ jobs:
       - name: Tag and push Docker image
         run: |
           docker tag graphemes-api:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api:${{ env.tag }}
-          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api --all-tags
+          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api:${{ env.tag }}

--- a/.github/workflows/graphemes_api_build.yaml
+++ b/.github/workflows/graphemes_api_build.yaml
@@ -1,0 +1,68 @@
+---
+name: Build and push graphemes-api image
+
+on:
+  push:
+    paths:
+      - graphemes-api/**
+    branches: [dev, test, main]
+  workflow_dispatch:
+
+# Cancel any currently running builds to save GitHub Actions hours.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: graphemes-api build and push
+    runs-on: ubuntu-latest
+    # Don't run on forks
+    if: github.repository == 'bcgov/standard-graphemes'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      # PRs to the `dev` branch push to the `dev` environment in OpenShift
+      # PRs to `test` push to `test`
+      # PRs to `main` push to `prod`
+      - name: Determine environment tag
+        id: env-tag
+        run: |
+          echo "Evaluating branch: ${{ github.ref }}";
+          if [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            echo "tag=dev" >> $GITHUB_ENV;
+          elif [[ "${{ github.ref }}" == "refs/heads/test" ]]; then
+            echo "tag=test" >> $GITHUB_ENV;
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "tag=prod" >> $GITHUB_ENV;
+          else
+            echo "Unknown branch: ${{ github.ref }}. Exiting...";
+            exit 1;
+          fi;
+        shell: bash
+
+      - name: Build image with docker build
+        run: docker build ./graphemes-api -f ./graphemes-api/Dockerfile -t graphemes-api:latest --build-arg GITHUB_SHA=${{ github.sha }}
+
+      - name: Login to OpenShift Silver image registry
+        uses: docker/login-action@v3
+        with:
+          registry: image-registry.apps.silver.devops.gov.bc.ca
+          # This refers to the serviceaccount name alone, not the fully qualified
+          # value that comes out of `oc whoami` when logged in as the SA.
+          # Ex: For `system:serviceaccount:<name space>:<service account name>`,
+          # just use `<service account name>`.
+          username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
+
+      - name: Tag and push Docker image
+        run: |
+          docker tag graphemes-api:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api:${{ env.tag }}
+          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api --all-tags


### PR DESCRIPTION
This PR adds a GitHub Actions workflow file for building the `graphemes-api` Express.js API server when new code is merged into `dev`, `test`, or `main`.

If the GHA workflow succeeds, a new image is pushed to the `graphemes-api` ImageStream in the `tools` namespace in OpenShift, and tagged using `dev` (from the `dev` branch), `test` (from `test`) or `prod` (from `main`).