### PR TITLE
Bump @types/node to v22.15.14

### DIFF
--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/express": "^5.0.1",
-        "@types/node": "^22.14.1",
+        "@types/node": "^22.15.14",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.26.0",
         "globals": "^16.0.0",
@@ -1189,9 +1189,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.15.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
+      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/express": "^5.0.1",
-    "@types/node": "^22.14.1",
+    "@types/node": "^22.15.14",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.26.0",
     "globals": "^16.0.0",


### PR DESCRIPTION
This bumps `@types/node` to latest in the `graphemes-api` package.json to trigger the test and build workflows from #34 and #35.