### PR TITLE
Bump graphemes-api devDependencies

### DIFF
--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -13,10 +13,10 @@
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/express": "^5.0.1",
-        "@types/node": "^22.15.14",
+        "@types/node": "^22.15.15",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.26.0",
-        "globals": "^16.0.0",
+        "globals": "^16.1.0",
         "nodemon": "^3.1.9",
         "prettier": "^3.5.3",
         "supertest": "^7.1.0",
@@ -1189,9 +1189,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
-      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
+      "version": "22.15.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.15.tgz",
+      "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2840,9 +2840,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
+      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -18,10 +18,10 @@
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/express": "^5.0.1",
-    "@types/node": "^22.15.14",
+    "@types/node": "^22.15.15",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.26.0",
-    "globals": "^16.0.0",
+    "globals": "^16.1.0",
     "nodemon": "^3.1.9",
     "prettier": "^3.5.3",
     "supertest": "^7.1.0",


### PR DESCRIPTION
This bumps the `graphemes-api` devDependencies to the latest available versions.

This PR will test the GHA workflows updated in #39.