### PR TITLE
Limit GITHUB_TOKEN permissions in Validator app workflows

### DIFF
--- a/.github/workflows/validator_backend_build.yaml
+++ b/.github/workflows/validator_backend_build.yaml
@@ -1,6 +1,10 @@
 ---
 name: Build and push Validator backend application image
 
+# Limit GITHUB_TOKEN permissions to only read repo contents.
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/validator_backend_test.yaml
+++ b/.github/workflows/validator_backend_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: Test validator backend
 
+# Limit GITHUB_TOKEN permissions to only read repo contents.
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/validator_frontend_build.yaml
+++ b/.github/workflows/validator_frontend_build.yaml
@@ -1,6 +1,10 @@
 ---
 name: Build and push Validator frontend application image
 
+# Limit GITHUB_TOKEN permissions to only read repo contents.
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/validator_frontend_test.yaml
+++ b/.github/workflows/validator_frontend_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: Test validator frontend
 
+# Limit GITHUB_TOKEN permissions to only read repo contents.
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow files associated with the Validator app to limit the permission of the `GITHUB_TOKEN`. These workflows only need to read from the repo.