### PR TITLE
Build graphemes-api Postgres connection string from multiple environment variables

### DIFF
--- a/graphemes-api/.env.example
+++ b/graphemes-api/.env.example
@@ -1,2 +1,9 @@
-DATABASE_URL=
+# Postgres database connection
+DB_HOST=
+DB_NAME=
+DB_PASS=
+DB_PORT=
+DB_USER=
+
+# Express API server port
 PORT=

--- a/graphemes-api/src/db/knexfile.ts
+++ b/graphemes-api/src/db/knexfile.ts
@@ -2,18 +2,36 @@ import dotenv from "dotenv";
 dotenv.config();
 import type { Knex } from "knex";
 
-const DATABASE_URL = process.env.DATABASE_URL;
+const DB_HOST = process.env.DB_HOST;
+const DB_NAME = process.env.DB_NAME;
+const DB_PASS = process.env.DB_PASS;
+const DB_PORT = process.env.DB_PORT;
+const DB_USER = process.env.DB_USER;
 
-if (!DATABASE_URL) {
-  console.warn("DATABASE_URL environment variable is undefined.");
+if (!DB_HOST) {
+  console.warn("Missing database configuration DB_HOST");
 }
+if (!DB_NAME) {
+  console.warn("Missing database configuration DB_NAME");
+}
+if (!DB_PASS) {
+  console.warn("Missing database configuration DB_PASS");
+}
+if (!DB_PORT) {
+  console.warn("Missing database configuration DB_PORT");
+}
+if (!DB_USER) {
+  console.warn("Missing database configuration DB_USER");
+}
+
+const connectionString = `postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
 
 const config: { [key: string]: Knex.Config } = {
   // Local development
   development: {
     client: "postgresql",
     connection: {
-      connectionString: DATABASE_URL,
+      connectionString,
       ssl: false,
     },
   },
@@ -22,7 +40,7 @@ const config: { [key: string]: Knex.Config } = {
   test: {
     client: "postgresql",
     connection: {
-      connectionString: DATABASE_URL,
+      connectionString,
       ssl: false,
     },
   },
@@ -31,7 +49,7 @@ const config: { [key: string]: Knex.Config } = {
   production: {
     client: "postgresql",
     connection: {
-      connectionString: DATABASE_URL,
+      connectionString,
       ssl: true,
     },
     pool: {


### PR DESCRIPTION
This PR updates the `graphemes-api` Knexfile to build a PostgreSQL `connectionString` value from individual environment variable components.

The reason for this change is that the composite connection string in the OpenShift Secret generated from the `crunchy-postgres` Helm chart contains the default database name `crunchy-postgres`, whereas I need to connect to a database that was manually added after the fact called `grapheme_v2`.

The secret being used here refers to a user `graphemes_api_user` with only limited `SELECT` permission on the `grapheme_v2` database, since we only need read access.

The other piece not represented here in version control is that I've logged into `grapheme_v2` as a privileged user and run the following script to set limited permissions for `grapheme-api-user`:

```sql
GRANT CONNECT ON DATABASE grapheme_v2 TO "graphemes-api-user";
GRANT USAGE ON SCHEMA public TO "graphemes-api-user";
GRANT SELECT ON ALL TABLES IN SCHEMA public TO "graphemes-api-user";
ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO "graphemes-api-user";
```