### PR TITLE
Filter empty strings from database before sending API response

### DIFF
--- a/graphemes-api/src/models/Language.ts
+++ b/graphemes-api/src/models/Language.ts
@@ -1,23 +1,25 @@
 import { z } from "zod";
 
+import splitCommaSeparatedString from "../utils/splitCommaSeparatedString.js";
+
 export const LanguageSchema = z.object({
   id: z.string().describe("Globally unique GUID for the language"),
   name: z.string().describe("The name of the language, e.g., Danez?gé?"),
   alternateNames: z
     .string()
-    .transform((val) => val.split(",").map((s) => s.trim()))
+    .transform(splitCommaSeparatedString)
     .describe(
       "Other names by which the language is known, e.g., “Kaska, Kaska Dena” for Danez?gé?"
     ),
   communityKeywords: z
     .string()
-    .transform((val) => val.split(",").map((s) => s.trim()))
+    .transform(splitCommaSeparatedString)
     .describe(
       "Keywords for communities where language is spoken, comma separated. e.g., “Zaa- Blueberry River, Doig River, Halfway River, Prophet River, Saulteau, West Moberly”"
     ),
   bcp47LanguageCodes: z
     .string()
-    .transform((val) => val.split(",").map((s) => s.trim()))
+    .transform(splitCommaSeparatedString)
     .describe(
       "The IETF BCP 47 language tag(s) for the language, comma separated; i.e., a standardized code that is used to identify this language on the Internet. e.g., “crx, caf” for the “Dakelh” language."
     ),

--- a/graphemes-api/src/utils/splitCommaSeparatedString.test.ts
+++ b/graphemes-api/src/utils/splitCommaSeparatedString.test.ts
@@ -13,6 +13,10 @@ describe("splitCommaSeparatedString()", () => {
     expect(extraCommasOutput.length).toBe(2);
     expect(extraCommasOutput[0]).toBe("shíshálh");
     expect(extraCommasOutput[1]).toBe("Sechelt");
+
+    const singleResultOutput = splitCommaSeparatedString(", ᑕᗸᒡ   , ");
+    expect(singleResultOutput.length).toBe(1);
+    expect(singleResultOutput[0]).toBe("ᑕᗸᒡ");
   });
 
   it("maintains graphemes equivalency", () => {

--- a/graphemes-api/src/utils/splitCommaSeparatedString.test.ts
+++ b/graphemes-api/src/utils/splitCommaSeparatedString.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+import splitCommaSeparatedString from "./splitCommaSeparatedString";
+
+describe("splitCommaSeparatedString()", () => {
+  it("strips whitespace appropriately", () => {
+    const emptyStringOutput = splitCommaSeparatedString("");
+    expect(emptyStringOutput.length).toBe(0);
+
+    const extraCommasOutput = splitCommaSeparatedString(
+      "shíshálh, , Sechelt , "
+    );
+    expect(extraCommasOutput.length).toBe(2);
+    expect(extraCommasOutput[0]).toBe("shíshálh");
+    expect(extraCommasOutput[1]).toBe("Sechelt");
+  });
+
+  it("maintains graphemes equivalency", () => {
+    const input =
+      "Aitchelitz, BOḰEĆEN, Pauquachin, Chawathil, Cheam Chehalis, Lake Cowichan, Halalt, Katzie, Kwantlen, Kwaw-kwaw-apilt, Kwikwetlem, kʷikʷəƛ̓əm, Leq’a:mel, Lyackson, MÁLEXEȽ, Malahat, Matsqui, Penelakut, Peters, Popkum, Qayqayt, Qualicum, Scia’new, Beecher Bay, Scowlitz, Seabird Island, Shxwhá:y, Shxw’owhamel, Skawahlook, Skowkale, Skwah, Snaw-naw-as, Nanoose, Snuneymuxw, Soowahlie, Squiala, Stz’uminus, Sumas, Tsawwassen, Tsleil-Waututh, Ts'uubaa-asatx, Tzeachten, Union Bar, xʷməθkʷəy̓əm, Musqueam, Yakweakwioose, Yale, Metro Vancouver, Chilliwack, Abbotsford, Nanaimo";
+    const output = splitCommaSeparatedString(input);
+
+    expect(output.length).toBe(51);
+    expect(output[1]).toBe("BOḰEĆEN");
+    expect(output[11]).toBe("kʷikʷəƛ̓əm");
+    expect(output[14]).toBe("MÁLEXEȽ");
+    expect(output[43]).toBe("xʷməθkʷəy̓əm");
+  });
+});

--- a/graphemes-api/src/utils/splitCommaSeparatedString.ts
+++ b/graphemes-api/src/utils/splitCommaSeparatedString.ts
@@ -7,6 +7,10 @@
  * @returns Array of filtered strings
  */
 export default function splitCommaSeparatedString(str: string): string[] {
+  if (!str.trim()) {
+    return [];
+  }
+
   return str
     .split(",")
     .map((s) => s.trim())

--- a/graphemes-api/src/utils/splitCommaSeparatedString.ts
+++ b/graphemes-api/src/utils/splitCommaSeparatedString.ts
@@ -1,0 +1,14 @@
+/**
+ * Given a string composed of text values separated by commas, return an array
+ * of the text chunks trimmed of whitespace and filtered of empty strings.
+ *
+ * Ex: "Taku River, Tlingit,  " -> ["Taku River", "Tlingit"]
+ * @param str Raw string from the database
+ * @returns Array of filtered strings
+ */
+export default function splitCommaSeparatedString(str: string): string[] {
+  return str
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+}


### PR DESCRIPTION
Currently, the Graphemes API will allow empty strings into array results when a database field contains no data. For example, the `communityKeywords` array in this result:

Before: GET `/api/v1/languages/feb6991f-6414-481d-8e8d-a1f906579028`
```json
{
  "id": "feb6991f-6414-481d-8e8d-a1f906579028",
  "name": "Nuxalk",
  "alternateNames": ["Bella Coola", "Nass"],
  "communityKeywords": [""],
  "bcp47LanguageCodes": ["blc"]
}
```

With this PR, I'm adding a common utility function to strip whitespace and filter empty strings from results:

After: GET `/api/v1/languages/feb6991f-6414-481d-8e8d-a1f906579028`
```json
{
  "id": "feb6991f-6414-481d-8e8d-a1f906579028",
  "name": "Nuxalk",
  "alternateNames": ["Bella Coola", "Nass"],
  "communityKeywords": [],
  "bcp47LanguageCodes": ["blc"]
}

```