### PR TITLE
Graphemes API rate limiting

### DIFF
--- a/graphemes-api/.env.example
+++ b/graphemes-api/.env.example
@@ -5,5 +5,7 @@ DB_PASS=
 DB_PORT=
 DB_USER=
 
-# Express API server port
+# Express API server configuration
 PORT=
+RATE_LIMIT_MAX=
+RATE_LIMIT_WINDOW_MS=

--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "knex": "^3.1.0",
         "pg": "^8.16.0",
         "zod": "^3.24.4"
@@ -2591,7 +2592,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
       "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "knex": "^3.1.0",
     "pg": "^8.16.0",
     "zod": "^3.24.4"

--- a/graphemes-api/src/index.ts
+++ b/graphemes-api/src/index.ts
@@ -8,7 +8,7 @@ import router from "./routes/index.js";
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Limit a single IP address to 20 requests/minute per API server pod.
+// Limit a single IP address to `max` requests/minute per API server pod.
 const limiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 100,

--- a/graphemes-api/src/index.ts
+++ b/graphemes-api/src/index.ts
@@ -8,10 +8,10 @@ import router from "./routes/index.js";
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-// Limit a single IP address to `max` requests/minute per API server pod.
+// Limit a single IP address to `max` requests/`windowMs` per API server pod.
 const limiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  max: 100,
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10), // Default 1 minute
+  max: parseInt(process.env.RATE_LIMIT_MAX || "100", 10),
   handler: (req, res, next, options) => {
     console.log("Rate limit hit for %s accessing %s", req.ip, req.originalUrl);
     res.status(options.statusCode).send(options.message);

--- a/graphemes-api/src/index.ts
+++ b/graphemes-api/src/index.ts
@@ -1,14 +1,26 @@
 import dotenv from "dotenv";
 dotenv.config();
 import express from "express";
+import rateLimit from "express-rate-limit";
 
 import router from "./routes/index.js";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Limit a single IP address to 20 requests/minute per API server pod.
+const limiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 100,
+  handler: (req, res, next, options) => {
+    console.log("Rate limit hit for %s accessing %s", req.ip, req.originalUrl);
+    res.status(options.statusCode).send(options.message);
+  },
+});
+
 // Middleware
 app.use(express.json());
+app.use(limiter);
 
 // Routes
 app.use("/", router);


### PR DESCRIPTION
This PR adds rate limiting middleware to the `graphemes-api` Express.js API server.

Note that this is a naive implementation because the application is deployed in OpenShift across several pods. A "real" implementation would need to account for traffic to all pods, not just a single pod instance.