### PR TITLE
Add trigger to graphemes-api dev deployment YAML

### DIFF
--- a/graphemes-api/openshift/dev/deployment.yaml
+++ b/graphemes-api/openshift/dev/deployment.yaml
@@ -24,6 +24,16 @@ spec:
   selector:
     matchLabels:
       app: graphemes-api
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - graphemes-api
+        from:
+          kind: ImageStreamTag
+          name: graphemes-api:dev
+          namespace: f343b4-tools
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
Currently, the `graphemes-api` will not auto-deploy on new pushes to its ImageStream because of a missing trigger. This PR adds that trigger to the deployment YAML, which is already applied in the `dev` namespace.