### PR TITLE
Use GHCR image repository for Graphemes API

### DIFF
--- a/.github/workflows/graphemes_api_build.yaml
+++ b/.github/workflows/graphemes_api_build.yaml
@@ -33,9 +33,9 @@ jobs:
         with:
           driver-opts: network=host
 
-      # PRs to the `dev` branch push to the `dev` environment in OpenShift
-      # PRs to `test` push to `test`
-      # PRs to `main` push to `prod`
+      # PRs to `dev` branch get deployed to `dev` environment in OpenShift
+      # PRs to `test` get deployed to `test`
+      # PRs to `main` get deployed to `prod`
       - name: Determine environment tag
         id: env-tag
         run: |
@@ -52,21 +52,13 @@ jobs:
           fi;
         shell: bash
 
-      - name: Build image with docker build
-        run: docker build ./graphemes-api -f ./graphemes-api/Dockerfile -t graphemes-api:latest --build-arg GITHUB_SHA=${{ github.sha }}
-
-      - name: Login to OpenShift Silver image registry
-        uses: docker/login-action@v3
+      # Use the GHCR builder action
+      - name: Build and push Docker image to GHCR
+        uses: bcgov-nr/action-builder-ghcr@ace71f7a527ca6fc43c15c7806314be5a4579d2c # v.2.3.0
         with:
-          registry: image-registry.apps.silver.devops.gov.bc.ca
-          # This refers to the serviceaccount name alone, not the fully qualified
-          # value that comes out of `oc whoami` when logged in as the SA.
-          # Ex: For `system:serviceaccount:<name space>:<service account name>`,
-          # just use `<service account name>`.
-          username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
-          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
-
-      - name: Tag and push Docker image
-        run: |
-          docker tag graphemes-api:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api:${{ env.tag }}
-          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/graphemes-api:${{ env.tag }}
+          package: graphemes-api
+          tag: ${{ env.tag }}
+          triggers: graphemes-api/**
+          build_context: ./graphemes-api
+          build_file: ./graphemes-api/Dockerfile
+          keep_versions: 10


### PR DESCRIPTION
This PR updates the Graphemes API build workflow to use the [bcgov-nr/action-builder-ghcr workflow](https://github.com/bcgov/action-builder-ghcr/) for building and pushing images to GitHub Container Registry rather than directly to an OpenShift ImageStream.