### PR TITLE
Add Graphemes API ImageStream YAML

### DIFF
--- a/graphemes-api/openshift/tools/ImageStream.yaml
+++ b/graphemes-api/openshift/tools/ImageStream.yaml
@@ -1,0 +1,28 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: graphemes-api
+  namespace: f343b4-tools
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: dev
+      from:
+        kind: DockerImage
+        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:dev
+      importPolicy:
+        scheduled: true
+    - name: test
+      from:
+        kind: DockerImage
+        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:test
+      importPolicy:
+        scheduled: true
+    - name: prod
+      from:
+        kind: DockerImage
+        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:prod
+      importPolicy:
+        scheduled: true


### PR DESCRIPTION
This pull request adds YAML for an OpenShift `ImageStream` that exists in our tools namespace and points to the built application images in GHCR that get built when code is merged to `dev`, `test`, or `main`.