### PR TITLE
Match API for comparing strings in Graphemes API

### DIFF
--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -8,6 +8,7 @@
       "name": "graphemes-api",
       "version": "0.0.1",
       "dependencies": {
+        "any-ascii": "^0.3.2",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
@@ -1654,6 +1655,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-ascii": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/any-ascii/-/any-ascii-0.3.2.tgz",
+      "integrity": "sha512-ABw9wA6PpMfmBbn5eeoOHJV86uqOcjEiuik6zV3dHCBfXu8kKWaCnKnrgzu9hLiFhvZYhdrRdVSo2RjjVhSycw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/anymatch": {

--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
+        "js-levenshtein-esm": "^2.0.0",
         "knex": "^3.1.0",
         "pg": "^8.16.0",
         "zod": "^3.25.28"
@@ -3116,6 +3117,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/js-levenshtein-esm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-2.0.0.tgz",
+      "integrity": "sha512-1n4LEPOL4wRXY8rOQcuA7Iuaphe5xCMayvufCzlLAi+hRsnBRDbSS6XPuV58CBVJxj5D9ApFLyjQ7KzFToyHBw==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",

--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -18,10 +18,10 @@
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "@types/express": "^5.0.2",
-        "@types/node": "^22.15.20",
+        "@types/node": "^22.15.21",
         "@types/supertest": "^6.0.3",
         "eslint": "^9.27.0",
-        "globals": "^16.1.0",
+        "globals": "^16.2.0",
         "nodemon": "^3.1.9",
         "prettier": "^3.5.3",
         "supertest": "^7.1.1",
@@ -1175,9 +1175,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.20.tgz",
-      "integrity": "sha512-A6BohGFRGHAscJsTslDCA9JG7qSJr/DWUvrvY8yi9IgnGtMxCyat7vvQ//MFa0DnLsyuS3wYTpLdw4Hf+Q5JXw==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
-      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/graphemes-api/package-lock.json
+++ b/graphemes-api/package-lock.json
@@ -13,7 +13,7 @@
         "express-rate-limit": "^7.5.0",
         "knex": "^3.1.0",
         "pg": "^8.16.0",
-        "zod": "^3.25.7"
+        "zod": "^3.25.28"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -4994,9 +4994,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
-      "integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
+      "version": "3.25.28",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -23,10 +23,10 @@
   "devDependencies": {
     "@eslint/js": "^9.27.0",
     "@types/express": "^5.0.2",
-    "@types/node": "^22.15.20",
+    "@types/node": "^22.15.21",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.27.0",
-    "globals": "^16.1.0",
+    "globals": "^16.2.0",
     "nodemon": "^3.1.9",
     "prettier": "^3.5.3",
     "supertest": "^7.1.1",

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -13,6 +13,7 @@
     "test": "npx vitest"
   },
   "dependencies": {
+    "any-ascii": "^0.3.2",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
+    "js-levenshtein-esm": "^2.0.0",
     "knex": "^3.1.0",
     "pg": "^8.16.0",
     "zod": "^3.25.28"

--- a/graphemes-api/package.json
+++ b/graphemes-api/package.json
@@ -18,7 +18,7 @@
     "express-rate-limit": "^7.5.0",
     "knex": "^3.1.0",
     "pg": "^8.16.0",
-    "zod": "^3.25.7"
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/graphemes-api/src/routes/api/v1/index.ts
+++ b/graphemes-api/src/routes/api/v1/index.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 
 import languagesRouter from "./languages/index.js";
+import matchRouter from "./match/index.js";
 
 const v1Router = Router();
 v1Router.use("/languages", languagesRouter);
+v1Router.use("/match", matchRouter);
 
 export default v1Router;

--- a/graphemes-api/src/routes/api/v1/match/index.ts
+++ b/graphemes-api/src/routes/api/v1/match/index.ts
@@ -28,15 +28,6 @@ matchRouter.post("/", async (req, res) => {
 
   const comparison = compareValues(value1, value2, threshold ?? 0.9);
 
-  if (!comparison) {
-    res.status(500).json({
-      error: "Internal Server Error",
-      message: "Something went wrong while processing your request",
-      statusCode: 500,
-    });
-    return;
-  }
-
   res.status(200).json({
     value1: comparison.comparisonValue1,
     value2: comparison.comparisonValue2,

--- a/graphemes-api/src/routes/api/v1/match/index.ts
+++ b/graphemes-api/src/routes/api/v1/match/index.ts
@@ -26,7 +26,13 @@ matchRouter.post("/", async (req, res) => {
 
   const { value1, value2, threshold } = req.body;
 
-  const comparison = compareValues(value1, value2, threshold ?? 0.9);
+  // Check for numeric threshold value and default to 0.9 if one isn't present.
+  const numericThreshold = parseFloat(threshold);
+  const comparison = compareValues(
+    value1,
+    value2,
+    !isNaN(numericThreshold) ? numericThreshold : 0.9
+  );
 
   res.status(200).json({
     value1: comparison.comparisonValue1,

--- a/graphemes-api/src/routes/api/v1/match/index.ts
+++ b/graphemes-api/src/routes/api/v1/match/index.ts
@@ -1,0 +1,49 @@
+import { Router } from "express";
+
+import compareValues from "../../../../utils/compareValues.js";
+
+const matchRouter = Router();
+
+matchRouter.post("/", async (req, res) => {
+  // Check the request body for values to be compared (`value1` and `value2`).
+  if (!req.body || Object.keys(req.body).length === 0) {
+    res.status(400).json({
+      error: "Bad Request",
+      message: "Request body is required",
+      statusCode: 400,
+    });
+    return;
+  }
+
+  if (!req.body.value1 || !req.body.value2) {
+    res.status(400).json({
+      error: "Bad Request",
+      message: "Request body requires values",
+      statusCode: 400,
+    });
+    return;
+  }
+
+  const { value1, value2, threshold } = req.body;
+
+  const comparison = compareValues(value1, value2, threshold ?? 0.9);
+
+  if (!comparison) {
+    res.status(500).json({
+      error: "Internal Server Error",
+      message: "Something went wrong while processing your request",
+      statusCode: 500,
+    });
+    return;
+  }
+
+  res.status(200).json({
+    value1: comparison.comparisonValue1,
+    value2: comparison.comparisonValue2,
+    threshold: comparison.threshold,
+    ratio: comparison.ratio,
+    isMatch: comparison.isMatch,
+  });
+});
+
+export default matchRouter;

--- a/graphemes-api/src/utils/compareValues.test.ts
+++ b/graphemes-api/src/utils/compareValues.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import compareValues from "./compareValues.js";
+
+describe("compareValues()", () => {
+  // Ratio of 0.5714285714285714, not a match given the default threshold 0.9
+  const resultWithDefaultThreshold = compareValues("kitten", "sitting");
+  it("returns an object with the expected keys", () => {
+    const keys = Object.keys(resultWithDefaultThreshold);
+    expect(keys.length).toBe(5);
+    expect(keys.includes("comparisonValue1"));
+    expect(keys.includes("comparisonValue2"));
+    expect(keys.includes("threshold"));
+    expect(keys.includes("ratio"));
+    expect(keys.includes("isMatch"));
+  });
+  it("reports the default threshold value used when one isn't passed", () => {
+    expect(resultWithDefaultThreshold.threshold).toBe(0.9);
+  });
+  it("reports the Levenshtein ratio of the values being compared", () => {
+    expect(resultWithDefaultThreshold.ratio.toFixed(2)).toBe("0.57");
+  });
+  it("reports an accurate boolean isMatch for the values being compared", () => {
+    expect(resultWithDefaultThreshold.isMatch).toBeFalsy();
+  });
+
+  // Ratio of 0.5714285714285714, a match given the specific threshold 0.5
+  const resultWithSpecificThreshold = compareValues("kitten", "sitting", 0.5);
+  it("reports the specified threshold value used when one is passed", () => {
+    expect(resultWithSpecificThreshold.threshold).toBe(0.5);
+  });
+  it("reports an accurate boolean isMatch for the values being compared with a low enough threshold", () => {
+    expect(resultWithSpecificThreshold.isMatch).toBeTruthy();
+  });
+
+  // Specific BC Parks names with known match booleans
+  const resultParks1 = compareValues("Aa Tlein Teix’i", "A Téix'gi Aan Tlein");
+  it("is not a match for: Aa Tlein Teix’i, A Téix'gi Aan Tlein", () => {
+    expect(resultParks1.isMatch).toBeFalsy();
+  });
+  const resultParks2 = compareValues("Hakai LÚxvbálís", "Hakai Lúxvbálís");
+  it("is a match for: Hakai LÚxvbálís, Hakai Lúxvbálís", () => {
+    expect(resultParks2.isMatch).toBeTruthy();
+  });
+  const resultsParks3 = compareValues("Ẁaẁley", "Ẁaẁaƛ");
+  it("is not a match for: Ẁaẁley, Ẁaẁaƛ", () => {
+    expect(resultsParks3.isMatch).toBeFalsy();
+  });
+  const resultsParks4 = compareValues("Xʷakʷəᕈnaxdəᕈma", "Xʷak̓ʷəʔnaxdəʔma");
+  it("is not a match for: Xʷakʷəᕈnaxdəᕈma, Xʷak̓ʷəʔnaxdəʔma", () => {
+    expect(resultsParks4.isMatch).toBeFalsy();
+  });
+  const resultsPark5 = compareValues("ɂNacinuxʷ", "ʔNacinuxʷ");
+  it("is a match for: ɂNacinuxʷ, ʔNacinuxʷ", () => {
+    expect(resultsPark5.isMatch).toBeTruthy();
+  });
+
+  it("whitespace is trimmed as expected", () => {
+    const result = compareValues("dog", "     dog          ");
+    expect(result.comparisonValue1).toBe("dog");
+    expect(result.comparisonValue2).toBe("dog");
+    expect(result.ratio).toBe(1);
+    expect(result.isMatch).toBeTruthy();
+  });
+});

--- a/graphemes-api/src/utils/compareValues.test.ts
+++ b/graphemes-api/src/utils/compareValues.test.ts
@@ -8,11 +8,11 @@ describe("compareValues()", () => {
   it("returns an object with the expected keys", () => {
     const keys = Object.keys(resultWithDefaultThreshold);
     expect(keys.length).toBe(5);
-    expect(keys.includes("comparisonValue1"));
-    expect(keys.includes("comparisonValue2"));
-    expect(keys.includes("threshold"));
-    expect(keys.includes("ratio"));
-    expect(keys.includes("isMatch"));
+    expect(keys.includes("comparisonValue1")).toBeTruthy();
+    expect(keys.includes("comparisonValue2")).toBeTruthy();
+    expect(keys.includes("threshold")).toBeTruthy();
+    expect(keys.includes("ratio")).toBeTruthy();
+    expect(keys.includes("isMatch")).toBeTruthy();
   });
   it("reports the default threshold value used when one isn't passed", () => {
     expect(resultWithDefaultThreshold.threshold).toBe(0.9);

--- a/graphemes-api/src/utils/compareValues.ts
+++ b/graphemes-api/src/utils/compareValues.ts
@@ -18,8 +18,8 @@ interface ComparisonDetails {
 
 /**
  * Given two strings to compare and an optional Levenshtein threshold (which
- * defaults to `0.9`), returns an object containing a `score` number and
- * `match` boolean indicating whether the strings are considered to be a match.
+ * defaults to `0.9`), returns an object containing a `ratio` number and
+ * `isMatch` boolean indicating whether the strings are considered to be a match.
  */
 export default function compareValues(
   value1: string,

--- a/graphemes-api/src/utils/compareValues.ts
+++ b/graphemes-api/src/utils/compareValues.ts
@@ -1,0 +1,50 @@
+import anyAscii from "any-ascii";
+import levenshteinDistance from "js-levenshtein-esm";
+
+import levenshteinRatio from "./levenshtein-ratio.js";
+
+interface ComparisonDetails {
+  /** First string value for comparison. */
+  comparisonValue1: string;
+  /** Second string value for comparison. */
+  comparisonValue2: string;
+  /** Levenshtein ratio threshold to check for a match. */
+  threshold: number;
+  /** Levenshtein ratio to compare to the threshold. */
+  ratio: number;
+  /** Whether the strings match based on the given threshold. */
+  isMatch: boolean;
+}
+
+/**
+ * Given two strings to compare and an optional Levenshtein threshold (which
+ * defaults to `0.9`), returns an object containing a `score` number and
+ * `match` boolean indicating whether the strings are considered to be a match.
+ */
+export default function compareValues(
+  value1: string,
+  value2: string,
+  threshold: number = 0.9
+): ComparisonDetails {
+  // Trim whitespace from the ends of the input values and cast to uppercase.
+  const capitalizedValue1 = value1.trim().toUpperCase();
+  const capitalizedValue2 = value2.trim().toUpperCase();
+
+  // Convert uppercase values to ASCII.
+  const ascii1 = anyAscii(capitalizedValue1);
+  const ascii2 = anyAscii(capitalizedValue2);
+
+  // Calculate Levenshtein distance of the ASCII values.
+  const distance = levenshteinDistance(ascii1, ascii2);
+
+  // Calculate Levenshtein ratio given the distance.
+  const ratio = levenshteinRatio(ascii1, ascii2, distance);
+
+  return {
+    comparisonValue1: value1.trim(),
+    comparisonValue2: value2.trim(),
+    threshold,
+    ratio,
+    isMatch: ratio >= threshold,
+  };
+}

--- a/graphemes-api/src/utils/levenshtein-ratio.test.ts
+++ b/graphemes-api/src/utils/levenshtein-ratio.test.ts
@@ -16,9 +16,7 @@ describe("levenshteinRatio()", () => {
     const str1 = "cat";
     const str2 = "";
     const distance = levenshteinDistance(str1, str2);
-    console.log("distance: ", distance);
     const ratio = levenshteinRatio(str1, str2, distance);
-    console.log("ratio: ", ratio);
     expect(ratio).toBe(0);
   });
 

--- a/graphemes-api/src/utils/levenshtein-ratio.test.ts
+++ b/graphemes-api/src/utils/levenshtein-ratio.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import levenshteinDistance from "js-levenshtein-esm";
+
+import levenshteinRatio from "./levenshtein-ratio.js";
+
+describe("levenshteinRatio()", () => {
+  it("returns a ratio of 1 for two empty strings", () => {
+    expect(levenshteinRatio("", "", 0)).toBe(1);
+  });
+
+  it("returns a ratio of 1 for two identical strings", () => {
+    expect(levenshteinRatio("hello", "hello", 0)).toBe(1);
+  });
+
+  it("returns a ratio of 0 when comparing a string to an empty string", () => {
+    const str1 = "cat";
+    const str2 = "";
+    const distance = levenshteinDistance(str1, str2);
+    console.log("distance: ", distance);
+    const ratio = levenshteinRatio(str1, str2, distance);
+    console.log("ratio: ", ratio);
+    expect(ratio).toBe(0);
+  });
+
+  it("returns the expected ratio for a known pair of strings", () => {
+    const str1 = "kitten";
+    const str2 = "sitting";
+    const distance = levenshteinDistance(str1, str2); // 3
+    const ratio = levenshteinRatio(str1, str2, distance); // 0.5714285714285714
+    expect(ratio.toFixed(2)).toBe("0.57");
+  });
+});

--- a/graphemes-api/src/utils/levenshtein-ratio.ts
+++ b/graphemes-api/src/utils/levenshtein-ratio.ts
@@ -1,0 +1,12 @@
+export default function levenshteinRatio(
+  a: string,
+  b: string,
+  distance: number
+): number {
+  const maxLen = Math.max(a.length, b.length);
+
+  // If maxLen is 0, both strings are empty and identical.
+  if (maxLen === 0) return 1;
+
+  return (maxLen - distance) / maxLen;
+}


### PR DESCRIPTION
This PR updates the Graphemes API to add a POST route to `/api/v1/match`. This route accepts POSTs with a request body like:

```json
{
  "value1": "example string",
  "value2": "example string"
}
```

... and it returns a comparison object with a score computed using the Levenshtein distance and ratio, given either a default threshold of `0.9` or an optional `threshold` value passed to the API.

Example `curl` usage:

```sh
curl -X POST http://localhost:3000/api/v1/match \                 
  -H "Content-Type: application/json" \
  -d '{"value1": "example", "value2": "exampl", "threshold": "0.5"}'
```

Response:

```json
{
  "value1": "example",
  "value2": "exampl",
  "threshold": "0.5",
  "ratio": 0.8571428571428571,
  "isMatch": true
}
```