### PR TITLE
Bump bcgov-nr/action-builder-ghcr to v4 in graphemes-api-build

### DIFF
--- a/.github/workflows/graphemes_api_build.yaml
+++ b/.github/workflows/graphemes_api_build.yaml
@@ -55,7 +55,7 @@ jobs:
 
       # Use the GHCR builder action
       - name: Build and push Docker image to GHCR
-        uses: bcgov-nr/action-builder-ghcr@ace71f7a527ca6fc43c15c7806314be5a4579d2c # v.2.3.0
+        uses: bcgov-nr/action-builder-ghcr@fd17bc1cbb16a60514e0df3966d42dff9fc232bc # v4.0.0
         with:
           package: graphemes-api
           tag: ${{ env.tag }}


### PR DESCRIPTION
This bumps the `bcgov-nr/action-builder-ghcr` to [v4](https://github.com/bcgov/action-builder-ghcr/releases/tag/v4.0.0) to try the SBOM generation capabilities.