### PR TITLE
Add Graphemes API GET route to /api/v1/sites/:id

### DIFF
--- a/graphemes-api/src/routes/api/v1/sites/index.ts
+++ b/graphemes-api/src/routes/api/v1/sites/index.ts
@@ -22,7 +22,7 @@ sitesRouter.get("/", async (req, res) => {
   }
 });
 
-// GET /api/v1/languages/:id - Fetch a single language by ID
+// GET /api/v1/sites/:id - Fetch a single language by ID
 sitesRouter.get("/:id", async (req, res) => {
   const { id } = req.params;
 

--- a/graphemes-api/src/routes/api/v1/sites/index.ts
+++ b/graphemes-api/src/routes/api/v1/sites/index.ts
@@ -22,4 +22,32 @@ sitesRouter.get("/", async (req, res) => {
   }
 });
 
+// GET /api/v1/languages/:id - Fetch a single language by ID
+sitesRouter.get("/:id", async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const row = await db("site")
+      .select(
+        "site_guid as id",
+        "slug",
+        "first_voices_site_name as firstVoicesSiteName",
+        "site_url as siteUrl",
+        "language_guid as languageId"
+      )
+      .where({ site_guid: id })
+      .first();
+    if (!row) {
+      res.status(404).json({ error: "Site not found" });
+      return;
+    }
+
+    const site = SiteSchema.parse(row); // Transformation happens here
+    res.json(site);
+  } catch (error) {
+    console.error("Error fetching site with site_guid '%s': %o", id, error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
+
 export default sitesRouter;


### PR DESCRIPTION
This PR adds a GET route to `/api/v1/sites/:id` to select a single Site based on its GUID:

Example response from `/api/v1/sites/f7dce3e7-8660-4df1-9794-efbd1fb5d55a`
```json
{
  "id": "f7dce3e7-8660-4df1-9794-efbd1fb5d55a",
  "slug": "cree-saulteau",
  "firstVoicesSiteName": "Cree (Saulteau First Nation)",
  "siteUrl": "https://firstvoices.com/cree-saulteau",
  "languageId": "2326173d-9d94-4fc0-808d-c81736d317e6"
}
```
