### PR TITLE
Graphemes API OpenShift manifests

### DIFF
--- a/graphemes-api/openshift/dev/Route.yaml
+++ b/graphemes-api/openshift/dev/Route.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: graphemes-api
+  namespace: f343b4-dev
+spec:
+  path: /
+  to:
+    name: graphemes-api
+    weight: 100
+    kind: Service
+  host: ""
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  port:
+    targetPort: 3000-tcp
+  alternateBackends: []

--- a/graphemes-api/openshift/dev/Service.yaml
+++ b/graphemes-api/openshift/dev/Service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graphemes-api
+  namespace: f343b4-dev
+spec:
+  selector:
+    app: graphemes-api
+  ports:
+    - name: 3000-tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/graphemes-api/openshift/dev/deployment.yaml
+++ b/graphemes-api/openshift/dev/deployment.yaml
@@ -24,7 +24,32 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
-          env: []
+          env:
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-postgres-pguser-graphemes-api-user
+                  key: pgbouncer-host
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-postgres-pguser-graphemes-api-user
+                  key: pgbouncer-port
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-postgres-pguser-graphemes-api-user
+                  key: user
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: crunchy-postgres-pguser-graphemes-api-user
+                  key: password
+            - name: DB_NAME
+              # This is a literal value because `crunchy-postgres`
+              # is the default database name in the PostgresCluster.
+              # This database name does not appear in the Secret.
+              value: grapheme_v2
       imagePullSecrets: []
   strategy:
     type: RollingUpdate

--- a/graphemes-api/openshift/prod/Route.yaml
+++ b/graphemes-api/openshift/prod/Route.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: graphemes-api
+  namespace: f343b4-prod
+spec:
+  path: /
+  to:
+    name: graphemes-api
+    weight: 100
+    kind: Service
+  host: ""
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  port:
+    targetPort: 3000-tcp
+  alternateBackends: []

--- a/graphemes-api/openshift/prod/Service.yaml
+++ b/graphemes-api/openshift/prod/Service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graphemes-api
+  namespace: f343b4-prod
+spec:
+  selector:
+    app: graphemes-api
+  ports:
+    - name: 3000-tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/graphemes-api/openshift/test/Deployment.yaml
+++ b/graphemes-api/openshift/test/Deployment.yaml
@@ -6,12 +6,12 @@ metadata:
   name: graphemes-api
   annotations:
     image.openshift.io/triggers: >-
-      [{"from":{"kind":"ImageStreamTag","name":"graphemes-api:dev","namespace":"f343b4-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","paused":false}]
+      [{"from":{"kind":"ImageStreamTag","name":"graphemes-api:test","namespace":"f343b4-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"container\")].image","paused":false}]
 spec:
   selector:
     matchLabels:
       app: graphemes-api
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/graphemes-api/openshift/test/Route.yaml
+++ b/graphemes-api/openshift/test/Route.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: graphemes-api
+  namespace: f343b4-test
+spec:
+  path: /
+  to:
+    name: graphemes-api
+    weight: 100
+    kind: Service
+  host: ""
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  port:
+    targetPort: 3000-tcp
+  alternateBackends: []

--- a/graphemes-api/openshift/test/Service.yaml
+++ b/graphemes-api/openshift/test/Service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graphemes-api
+  namespace: f343b4-test
+spec:
+  selector:
+    app: graphemes-api
+  ports:
+    - name: 3000-tcp
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/graphemes-api/openshift/tools/ImageStream.yaml
+++ b/graphemes-api/openshift/tools/ImageStream.yaml
@@ -1,28 +1,6 @@
 ---
-kind: ImageStream
 apiVersion: image.openshift.io/v1
+kind: ImageStream
 metadata:
   name: graphemes-api
   namespace: f343b4-tools
-spec:
-  lookupPolicy:
-    local: false
-  tags:
-    - name: dev
-      from:
-        kind: DockerImage
-        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:dev
-      importPolicy:
-        scheduled: true
-    - name: test
-      from:
-        kind: DockerImage
-        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:test
-      importPolicy:
-        scheduled: true
-    - name: prod
-      from:
-        kind: DockerImage
-        name: ghcr.io/bcgov/standard-graphemes/graphemes-api:prod
-      importPolicy:
-        scheduled: true


### PR DESCRIPTION
This adds the currently-applied OpenShift manifests for the Graphemes API.